### PR TITLE
fetch namespaces when initializing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Router, Switch, Route } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
-import { ThemeProvider, CssBaseline, createMuiTheme } from '@material-ui/core';
+import {
+  ThemeProvider,
+  CssBaseline,
+  CircularProgress,
+  createMuiTheme,
+} from '@material-ui/core';
 import { Dashboard } from './views/Dashboard';
 import { Messages } from './views/Messages';
 import { AppWrapper } from './components/AppWrapper';
+import { NamespaceContext } from './contexts/NamespaceContext';
+import { INamespace } from './interfaces';
 
 const history = createBrowserHistory();
+const NAMESPACE_LOCALSTORAGE_KEY = 'ff:namespace';
 export const theme = createMuiTheme({
   palette: {
     type: 'dark',
@@ -35,17 +43,56 @@ export const theme = createMuiTheme({
 });
 
 function App() {
+  const [initializing, setInitializing] = useState(true);
+  const [namespaces, setNamespaces] = useState<INamespace[]>([]);
+  const [selectedNamespace, setSelectedNamespace] = useState<string>('');
+
+  useEffect(() => {
+    fetch('/api/v1/namespaces')
+      .then(async (response) => {
+        if (response.ok) {
+          const ns: INamespace[] = await response.json();
+          setNamespaces(ns);
+          const storageItem = window.localStorage.getItem(
+            NAMESPACE_LOCALSTORAGE_KEY
+          );
+          if (storageItem) {
+            setSelectedNamespace(storageItem);
+          } else if (ns.length !== 0) {
+            setSelectedNamespace(ns[0].name);
+            window.localStorage.setItem(NAMESPACE_LOCALSTORAGE_KEY, ns[0].name);
+          }
+        }
+      })
+      .finally(() => {
+        setInitializing(false);
+      });
+  }, []);
+
+  if (initializing) {
+    return <CircularProgress />;
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Router history={history}>
-        <AppWrapper>
-          <Switch>
-            <Route exact path="/" render={() => <Dashboard />} />
-            <Route exact path="/messages" render={() => <Messages />} />
-          </Switch>
-        </AppWrapper>
-      </Router>
+      <NamespaceContext.Provider
+        value={{
+          namespaces,
+          selectedNamespace,
+          setNamespaces,
+          setSelectedNamespace,
+        }}
+      >
+        <Router history={history}>
+          <AppWrapper>
+            <Switch>
+              <Route exact path="/" render={() => <Dashboard />} />
+              <Route exact path="/messages" render={() => <Messages />} />
+            </Switch>
+          </AppWrapper>
+        </Router>
+      </NamespaceContext.Provider>
     </ThemeProvider>
   );
 }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -33,7 +33,7 @@ export const DataTable: React.FC<Props> = ({
       <Grid>
         <Typography className={classes.header}>{header}</Typography>
       </Grid>
-      <Grid xs={12}>
+      <Grid item xs={12}>
         <TableContainer className={classes.tableContainer}>
           <Table stickyHeader={stickyHeader}>
             <TableHead>

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -8,7 +8,6 @@ import {
   makeStyles,
   Hidden,
   IconButton,
-  SvgIconProps,
 } from '@material-ui/core';
 import clsx from 'clsx';
 import CubeOutlineIcon from 'mdi-react/CubeOutlineIcon';

--- a/src/contexts/NamespaceContext.ts
+++ b/src/contexts/NamespaceContext.ts
@@ -1,0 +1,20 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import { INamespace } from '../interfaces';
+
+export interface INamespaceContext {
+  selectedNamespace: string;
+  setSelectedNamespace: Dispatch<SetStateAction<string>>;
+  namespaces: INamespace[];
+  setNamespaces: Dispatch<SetStateAction<INamespace[]>>;
+}
+
+export const NamespaceContext = React.createContext<INamespaceContext>({
+  selectedNamespace: '',
+  setNamespaces: () => {
+    /* default value */
+  },
+  namespaces: [],
+  setSelectedNamespace: () => {
+    /* default value */
+  },
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,6 +39,15 @@ export interface IMessage {
   sequence: number;
 }
 
+export interface INamespace {
+  id: string;
+  name: string;
+  description: string;
+  type: string;
+  created: string;
+  confirmed: string;
+}
+
 export interface ITransaction {
   confirmed: number;
   created: number;

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import {
   Grid,
   makeStyles,
@@ -13,6 +13,7 @@ import { IDataTableRecord, IMessage, ITransaction } from '../interfaces';
 import { DataTable } from '../components/DataTable/DataTable';
 import dayjs from 'dayjs';
 import { AddressPopover } from '../components/AddressPopover';
+import { NamespaceContext } from '../contexts/NamespaceContext';
 
 export const Dashboard: React.FC = () => {
   const classes = useStyles();
@@ -20,12 +21,13 @@ export const Dashboard: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [messages, setMessages] = useState<IMessage[]>([]);
   const [transactions, setTransactions] = useState<ITransaction[]>([]);
+  const { selectedNamespace } = useContext(NamespaceContext);
 
   useEffect(() => {
     setLoading(true);
     Promise.all([
-      fetch(`/api/v1/ns/ns1/messages?limit=5`),
-      fetch(`/api/v1/ns/ns1/transactions?limit=1`),
+      fetch(`/api/v1/namespaces/${selectedNamespace}/messages?limit=5`),
+      fetch(`/api/v1/namespaces/${selectedNamespace}/transactions?limit=1`),
     ])
       .then(async ([messageResponse, transactionResponse]) => {
         if (messageResponse.ok && transactionResponse.ok) {
@@ -36,13 +38,17 @@ export const Dashboard: React.FC = () => {
       .finally(() => {
         setLoading(false);
       });
-  }, []);
+  }, [selectedNamespace]);
 
   const summaryPanel = (label: string, value: string | number) => (
     <Card>
       <CardContent className={classes.content}>
-        <Typography className={classes.summaryLabel}>{label}</Typography>
-        <Typography className={classes.summaryValue}>{value}</Typography>
+        <Typography noWrap className={classes.summaryLabel}>
+          {label}
+        </Typography>
+        <Typography noWrap className={classes.summaryValue}>
+          {value}
+        </Typography>
       </CardContent>
     </Card>
   );

--- a/src/views/Messages.tsx
+++ b/src/views/Messages.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useContext } from 'react';
 import { Grid, Typography, makeStyles } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
@@ -7,12 +7,14 @@ import { DataTable } from '../components/DataTable/DataTable';
 import { AddressPopover } from '../components/AddressPopover';
 import { MessageDetails } from '../components/MessageDetails';
 import CheckIcon from 'mdi-react/CheckIcon';
+import { NamespaceContext } from '../contexts/NamespaceContext';
 
 export const Messages: React.FC = () => {
   const { t } = useTranslation();
   const classes = useStyles();
   const [messages, setMessages] = useState<IMessage[]>([]);
   const [viewMessage, setViewMessage] = useState<IMessage | undefined>();
+  const { selectedNamespace } = useContext(NamespaceContext);
 
   const columnHeaders = [
     t('author'),
@@ -25,14 +27,16 @@ export const Messages: React.FC = () => {
   ];
 
   const queryMessages = useCallback(() => {
-    fetch('/api/v1/ns/ns1/messages').then(async (response) => {
-      if (response.ok) {
-        setMessages(await response.json());
-      } else {
-        console.log('error fetching messages');
+    fetch(`/api/v1/namespaces/${selectedNamespace}/messages`).then(
+      async (response) => {
+        if (response.ok) {
+          setMessages(await response.json());
+        } else {
+          console.log('error fetching messages');
+        }
       }
-    });
-  }, []);
+    );
+  }, [selectedNamespace]);
 
   useEffect(() => {
     queryMessages();


### PR DESCRIPTION
During app initialization, namespaces are fetched and stored in a context. The default namespace (currently implemented as the first element in the namespace array), will be stored in local storage and used as the namespace for subsequent API calls.

Future work entails a menu to change namespaces.