### PR TITLE
add global namespace select

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,27 @@ export const theme = createMuiTheme({
         paddingRight: 25,
       },
     },
+    MuiSelect: {
+      root: {
+        color: '#6E7780',
+      },
+      select: {
+        '&:focus': {
+          backgroundColor: 'yellobw',
+        },
+      },
+      icon: {
+        color: '#6E7780',
+      },
+    },
+    MuiFormLabel: {
+      root: {
+        '&$focused': {
+          backgroundColor: '#1E242A',
+          color: '#6E7780',
+        },
+      },
+    },
   },
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import { INamespace } from './interfaces';
 const history = createBrowserHistory({
   basename: process.env.PUBLIC_URL,
 });
-const NAMESPACE_LOCALSTORAGE_KEY = 'ff:namespace';
+export const NAMESPACE_LOCALSTORAGE_KEY = 'ff:namespace';
 export const theme = createMuiTheme({
   palette: {
     type: 'dark',
@@ -49,7 +49,7 @@ export const theme = createMuiTheme({
       },
       select: {
         '&:focus': {
-          backgroundColor: 'yellobw',
+          backgroundColor: '#1E242A',
         },
       },
       icon: {

--- a/src/components/AppWrapper.tsx
+++ b/src/components/AppWrapper.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Navigation } from './Navigation/Navigation';
 import { makeStyles } from '@material-ui/core';
 import { HiddenAppBar } from './HiddenAppBar';
+import { Header } from './Header/Header';
 
 export const AppWrapper: React.FC = ({ children }) => {
   const classes = useStyles();
@@ -18,6 +19,7 @@ export const AppWrapper: React.FC = ({ children }) => {
           navigationOpen={navigationOpen}
           setNavigationOpen={setNavigationOpen}
         />
+        <Header />
         {children}
       </main>
     </div>

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -19,7 +19,7 @@ interface Props {
   stickyHeader?: boolean;
   pagination?: JSX.Element;
   header?: string;
-  height?: string;
+  minHeight?: string;
   maxHeight?: string;
 }
 
@@ -29,7 +29,7 @@ export const DataTable: React.FC<Props> = ({
   stickyHeader,
   pagination,
   header,
-  height,
+  minHeight,
   maxHeight,
 }) => {
   const classes = useStyles();
@@ -43,7 +43,7 @@ export const DataTable: React.FC<Props> = ({
       )}
       <Grid item xs={12}>
         <TableContainer
-          style={{ maxHeight, height }}
+          style={{ maxHeight, minHeight }}
           className={classes.tableContainer}
         >
           <Table stickyHeader={stickyHeader}>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Grid, Hidden, makeStyles } from '@material-ui/core';
+import { NamespaceMenu } from './NamespaceMenu';
+
+export const Header: React.FC = () => {
+  const classes = useStyles();
+
+  return (
+    <Hidden implementation="js" smDown>
+      <header className={classes.headerGrid}>
+        <Grid container alignItems="center" justify="flex-end">
+          <Grid item>
+            <NamespaceMenu />
+          </Grid>
+        </Grid>
+      </header>
+    </Hidden>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  headerGrid: {
+    margin: theme.spacing(3),
+  },
+}));

--- a/src/components/Header/NamespaceMenu.tsx
+++ b/src/components/Header/NamespaceMenu.tsx
@@ -1,0 +1,47 @@
+import React, { useContext } from 'react';
+import { TextField, MenuItem, makeStyles } from '@material-ui/core';
+import { NamespaceContext } from '../../contexts/NamespaceContext';
+import { NAMESPACE_LOCALSTORAGE_KEY } from '../../App';
+
+export const NamespaceMenu: React.FC = () => {
+  const classes = useStyles();
+  const { namespaces, selectedNamespace, setSelectedNamespace } = useContext(
+    NamespaceContext
+  );
+
+  const handleSelectNamespace = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setSelectedNamespace(event.target.value);
+    window.localStorage.setItem(NAMESPACE_LOCALSTORAGE_KEY, event.target.value);
+  };
+
+  return (
+    <>
+      <form noValidate autoComplete="off">
+        <TextField
+          select
+          label="Namespace"
+          value={selectedNamespace}
+          onChange={handleSelectNamespace}
+          InputProps={{
+            disableUnderline: true,
+          }}
+          className={classes.form}
+        >
+          {namespaces.map((namespace) => (
+            <MenuItem key={namespace.name} value={namespace.name}>
+              {namespace.name}
+            </MenuItem>
+          ))}
+        </TextField>
+      </form>
+    </>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  form: {
+    minWidth: '10ch',
+  },
+}));

--- a/src/components/HiddenAppBar.tsx
+++ b/src/components/HiddenAppBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { IconButton, Hidden, makeStyles, Box } from '@material-ui/core';
 import MenuIcon from 'mdi-react/MenuIcon';
 import { ReactComponent as LogoIconSVG } from '../svg/ff-logo-symbol-white.svg';
+import { NamespaceMenu } from './Header/NamespaceMenu';
 
 type Props = {
   navigationOpen: boolean;
@@ -26,6 +27,9 @@ export const HiddenAppBar: React.FC<Props> = ({
             <MenuIcon />
           </IconButton>
           <LogoIconSVG className={classes.logo} />
+        </div>
+        <div>
+          <NamespaceMenu />
         </div>
       </Box>
     </Hidden>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -132,7 +132,7 @@ export const Dashboard: React.FC = () => {
             )}
           </Grid>
         </Grid>
-        <Grid item>
+        <Grid container item>
           <DataTable
             minHeight="300px"
             maxHeight="calc(100vh - 340px)"

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -134,6 +134,8 @@ export const Dashboard: React.FC = () => {
         </Grid>
         <Grid item>
           <DataTable
+            minHeight="300px"
+            maxHeight="calc(100vh - 340px)"
             columnHeaders={messageColumnHeaders}
             records={messageRecords}
             header={t('latestMessages')}
@@ -146,7 +148,7 @@ export const Dashboard: React.FC = () => {
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    paddingTop: 80,
+    paddingTop: 20,
     paddingLeft: 120,
     paddingRight: 120,
     [theme.breakpoints.down('sm')]: {

--- a/src/views/Data.tsx
+++ b/src/views/Data.tsx
@@ -108,6 +108,7 @@ export const Data: React.FC = () => {
         </Grid>
         <Grid container item>
           <DataTable
+            minHeight="300px"
             maxHeight="calc(100vh - 340px)"
             {...{ columnHeaders }}
             {...{ records }}
@@ -121,7 +122,7 @@ export const Data: React.FC = () => {
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    paddingTop: 80,
+    paddingTop: 20,
     paddingLeft: 120,
     paddingRight: 120,
     [theme.breakpoints.down('sm')]: {

--- a/src/views/Messages.tsx
+++ b/src/views/Messages.tsx
@@ -125,6 +125,7 @@ export const Messages: React.FC = () => {
         </Grid>
         <Grid container item>
           <DataTable
+            minHeight="300px"
             maxHeight="calc(100vh - 340px)"
             {...{ columnHeaders }}
             {...{ records }}
@@ -145,7 +146,7 @@ export const Messages: React.FC = () => {
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    paddingTop: 80,
+    paddingTop: 20,
     paddingLeft: 120,
     paddingRight: 120,
     [theme.breakpoints.down('sm')]: {

--- a/src/views/Transactions.tsx
+++ b/src/views/Transactions.tsx
@@ -112,6 +112,7 @@ export const Transactions: React.FC = () => {
         </Grid>
         <Grid container item>
           <DataTable
+            minHeight="300px"
             maxHeight="calc(100vh - 340px)"
             {...{ columnHeaders }}
             {...{ records }}
@@ -125,7 +126,7 @@ export const Transactions: React.FC = () => {
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    paddingTop: 80,
+    paddingTop: 20,
     paddingLeft: 120,
     paddingRight: 120,
     [theme.breakpoints.down('sm')]: {


### PR DESCRIPTION
Now namespaces can be changed via a select form in the header that persists across all pages. 

<img width="1665" alt="Screen Shot 2021-05-20 at 1 45 52 PM" src="https://user-images.githubusercontent.com/10987380/119025464-27330f00-b972-11eb-9022-0d7b37930a2c.png">
<img width="1678" alt="Screen Shot 2021-05-20 at 1 45 42 PM" src="https://user-images.githubusercontent.com/10987380/119025467-27330f00-b972-11eb-9de0-4fcbc22f0d0e.png">
