### PR TITLE
Initial timeline view

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module.exports = {
   extends: [
     'react-app', // Create React App base settings
@@ -6,12 +22,7 @@ module.exports = {
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display Prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
   plugins: ['header'],
-  overrides: [
-    {
-      files: ['src/**/*.ts', 'src/**/*.js'],
-      rules: {
-        'header/header': [2, 'resources/license-header.js'],
-      },
-    },
-  ],
+  rules: {
+    'header/header': [2, 'resources/license-header.js'],
+  },
 };

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Firefly UI
+# FireFly UI

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <base href="%PUBLIC_URL%/" />
-    <title>Firefly Explorer</title>
+    <title>FireFly Explorer</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Firefly Explorer",
-  "name": "Firefly Explorer",
+  "short_name": "FireFly Explorer",
+  "name": "FireFly Explorer",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,13 +24,14 @@ import {
   createMuiTheme,
 } from '@material-ui/core';
 import { Dashboard } from './views/Dashboard';
-import { Messages } from './views/Messages';
+import { Messages } from './views/Messages/Messages';
 import { Transactions } from './views/Transactions/Transactions';
 import { TransactionDetails } from './views/Transactions/TransactionDetails';
 import { Data } from './views/Data';
 import { AppWrapper } from './components/AppWrapper';
 import { NamespaceContext } from './contexts/NamespaceContext';
-import { INamespace } from './interfaces';
+import { ApplicationContext } from './contexts/ApplicationContext';
+import { INamespace, DataView } from './interfaces';
 
 const history = createBrowserHistory({
   basename: process.env.PUBLIC_URL,
@@ -51,6 +52,9 @@ export const theme = createMuiTheme({
     },
     tableRowAlternate: {
       main: '#21272D',
+    },
+    timelineBackground: {
+      main: '#2D353C',
     },
   },
   overrides: {
@@ -88,6 +92,7 @@ function App() {
   const [initializing, setInitializing] = useState(true);
   const [namespaces, setNamespaces] = useState<INamespace[]>([]);
   const [selectedNamespace, setSelectedNamespace] = useState<string>('');
+  const [dataView, setDataView] = useState<DataView>('list');
 
   useEffect(() => {
     fetch('/api/v1/namespaces')
@@ -126,25 +131,27 @@ function App() {
           setSelectedNamespace,
         }}
       >
-        <Router history={history}>
-          <AppWrapper>
-            <Switch>
-              <Route exact path="/" render={() => <Dashboard />} />
-              <Route exact path="/messages" render={() => <Messages />} />
-              <Route exact path="/data" render={() => <Data />} />
-              <Route
-                exact
-                path="/transactions"
-                render={() => <Transactions />}
-              />
-              <Route
-                exact
-                path="/transactions/:id"
-                render={() => <TransactionDetails />}
-              />
-            </Switch>
-          </AppWrapper>
-        </Router>
+        <ApplicationContext.Provider value={{ dataView, setDataView }}>
+          <Router history={history}>
+            <AppWrapper>
+              <Switch>
+                <Route exact path="/" render={() => <Dashboard />} />
+                <Route exact path="/messages" render={() => <Messages />} />
+                <Route exact path="/data" render={() => <Data />} />
+                <Route
+                  exact
+                  path="/transactions"
+                  render={() => <Transactions />}
+                />
+                <Route
+                  exact
+                  path="/transactions/:id"
+                  render={() => <TransactionDetails />}
+                />
+              </Switch>
+            </AppWrapper>
+          </Router>
+        </ApplicationContext.Provider>
       </NamespaceContext.Provider>
     </ThemeProvider>
   );

--- a/src/components/DataTimeline/DataTimeline.tsx
+++ b/src/components/DataTimeline/DataTimeline.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Paper, makeStyles } from '@material-ui/core';
+import { Timeline } from '@material-ui/lab';
+import { ITimelineItem } from '../../interfaces';
+import { TimelineItemWrapper } from './TimelineItemWrapper';
+
+interface Props {
+  items: ITimelineItem[];
+}
+
+export const DataTimeline: React.FC<Props> = ({ items }) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <Paper className={classes.paper}>
+        <Timeline>
+          {items.map((item) => (
+            <TimelineItemWrapper item={item} opposite />
+          ))}
+        </Timeline>
+      </Paper>
+    </>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    padding: theme.spacing(2),
+    width: '100%',
+    maxHeight: 'calc(100vh - 100px)',
+    overflow: 'auto',
+  },
+}));

--- a/src/components/DataTimeline/DataTimeline.tsx
+++ b/src/components/DataTimeline/DataTimeline.tsx
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from 'react';
 import { Paper, makeStyles } from '@material-ui/core';
 import { Timeline } from '@material-ui/lab';

--- a/src/components/DataTimeline/TimelineItemWrapper.tsx
+++ b/src/components/DataTimeline/TimelineItemWrapper.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
-
 import { ITimelineItem } from '../../interfaces';
 import { OppositeTimelineItem } from './TimelineItems/OppositeTimelineItem';
 import { TimelineItem } from './TimelineItems/TimelineItem';
@@ -21,10 +19,3 @@ export const TimelineItemWrapper: React.FC<Props> = ({ item, opposite }) => {
     </>
   );
 };
-
-const useStyles = makeStyles((theme) => ({
-  paper: {
-    padding: theme.spacing(2),
-    backgroundColor: theme.palette.timelineBackground.main,
-  },
-}));

--- a/src/components/DataTimeline/TimelineItemWrapper.tsx
+++ b/src/components/DataTimeline/TimelineItemWrapper.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core';
+
+import { ITimelineItem } from '../../interfaces';
+import { OppositeTimelineItem } from './TimelineItems/OppositeTimelineItem';
+import { TimelineItem } from './TimelineItems/TimelineItem';
+
+interface Props {
+  item: ITimelineItem;
+  opposite?: boolean;
+}
+
+export const TimelineItemWrapper: React.FC<Props> = ({ item, opposite }) => {
+  return (
+    <>
+      {opposite ? (
+        <OppositeTimelineItem item={item} />
+      ) : (
+        <TimelineItem item={item} />
+      )}
+    </>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    padding: theme.spacing(2),
+    backgroundColor: theme.palette.timelineBackground.main,
+  },
+}));

--- a/src/components/DataTimeline/TimelineItemWrapper.tsx
+++ b/src/components/DataTimeline/TimelineItemWrapper.tsx
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from 'react';
 import { ITimelineItem } from '../../interfaces';
 import { OppositeTimelineItem } from './TimelineItems/OppositeTimelineItem';

--- a/src/components/DataTimeline/TimelineItems/OppositeTimelineItem.tsx
+++ b/src/components/DataTimeline/TimelineItems/OppositeTimelineItem.tsx
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from 'react';
 import {
   TimelineItem,

--- a/src/components/DataTimeline/TimelineItems/OppositeTimelineItem.tsx
+++ b/src/components/DataTimeline/TimelineItems/OppositeTimelineItem.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  TimelineItem,
+  TimelineSeparator,
+  TimelineContent,
+  TimelineOppositeContent,
+  TimelineDot,
+  TimelineConnector,
+} from '@material-ui/lab';
+import { makeStyles } from '@material-ui/core';
+import { TimelineContentPanel } from './TimelineContentPanel';
+import { ITimelineItem } from '../../../interfaces';
+
+interface Props {
+  item: ITimelineItem;
+}
+
+export const OppositeTimelineItem: React.FC<Props> = ({ item }) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <TimelineItem>
+        <TimelineOppositeContent>
+          <TimelineContentPanel
+            title={item.title}
+            description={item.description}
+            onClick={item.onClick}
+          />
+        </TimelineOppositeContent>
+        <TimelineSeparator>
+          <TimelineDot className={classes.dot}>
+            {item.icon ? item.icon : undefined}
+          </TimelineDot>
+          <TimelineConnector />
+        </TimelineSeparator>
+        <TimelineContent>{item.time}</TimelineContent>
+      </TimelineItem>
+    </>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  dot: {
+    backgroundColor: theme.palette.timelineBackground.main,
+  },
+}));

--- a/src/components/DataTimeline/TimelineItems/TimelineContentPanel.tsx
+++ b/src/components/DataTimeline/TimelineItems/TimelineContentPanel.tsx
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from 'react';
 import { makeStyles, Paper, Typography, Grid } from '@material-ui/core';
 import clsx from 'clsx';

--- a/src/components/DataTimeline/TimelineItems/TimelineContentPanel.tsx
+++ b/src/components/DataTimeline/TimelineItems/TimelineContentPanel.tsx
@@ -43,7 +43,9 @@ export const TimelineContentPanel: React.FC<Props> = ({
             <Typography className={classes.title}>{title}</Typography>
           </Grid>
           <Grid item>
-            <Typography>{description}</Typography>
+            <Typography className={classes.description}>
+              {description}
+            </Typography>
           </Grid>
         </Grid>
       </Paper>
@@ -59,6 +61,10 @@ const useStyles = makeStyles((theme) => ({
   },
   title: {
     fontWeight: 'bold',
+    fontSize: 14,
+  },
+  description: {
+    fontSize: 12,
   },
   container: {
     alignItems: 'flex-start',

--- a/src/components/DataTimeline/TimelineItems/TimelineContentPanel.tsx
+++ b/src/components/DataTimeline/TimelineItems/TimelineContentPanel.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { makeStyles, Paper, Typography, Grid } from '@material-ui/core';
+import clsx from 'clsx';
+
+interface Props {
+  title?: string;
+  description?: string;
+  onClick?: () => void;
+}
+
+export const TimelineContentPanel: React.FC<Props> = ({
+  title,
+  description,
+  onClick,
+}) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <Paper
+        elevation={3}
+        className={clsx(classes.paper, onClick && classes.clickable)}
+        onClick={onClick}
+      >
+        <Grid container className={classes.container} direction="column">
+          <Grid item>
+            <Typography className={classes.title}>{title}</Typography>
+          </Grid>
+          <Grid item>
+            <Typography>{description}</Typography>
+          </Grid>
+        </Grid>
+      </Paper>
+    </>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    padding: theme.spacing(2),
+    backgroundColor: theme.palette.timelineBackground.main,
+    borderLeft: `4px solid ${theme.palette.primary.main}`,
+  },
+  title: {
+    fontWeight: 'bold',
+  },
+  container: {
+    alignItems: 'flex-start',
+  },
+  clickable: {
+    cursor: 'pointer',
+  },
+}));

--- a/src/components/DataTimeline/TimelineItems/TimelineItem.tsx
+++ b/src/components/DataTimeline/TimelineItems/TimelineItem.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core';
+import {
+  TimelineSeparator,
+  TimelineContent,
+  TimelineOppositeContent,
+  TimelineDot,
+  TimelineConnector,
+  TimelineItem as TItem,
+} from '@material-ui/lab';
+import { ITimelineItem } from '../../../interfaces';
+import { TimelineContentPanel } from './TimelineContentPanel';
+
+interface Props {
+  item: ITimelineItem;
+}
+
+export const TimelineItem: React.FC<Props> = ({ item }) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <TItem>
+        <TimelineOppositeContent>{item.time}</TimelineOppositeContent>
+        <TimelineSeparator>
+          <TimelineDot className={classes.dot}>
+            {item.icon ? item.icon : undefined}
+          </TimelineDot>
+          <TimelineConnector />
+        </TimelineSeparator>
+        <TimelineContent>
+          <TimelineContentPanel
+            title={item.title}
+            description={item.description}
+            onClick={item.onClick}
+          />
+        </TimelineContent>
+      </TItem>
+    </>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  dot: {
+    backgroundColor: theme.palette.timelineBackground.main,
+  },
+}));

--- a/src/components/DataTimeline/TimelineItems/TimelineItem.tsx
+++ b/src/components/DataTimeline/TimelineItems/TimelineItem.tsx
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
 import {

--- a/src/components/DataViewSwitch.tsx
+++ b/src/components/DataViewSwitch.tsx
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React, { useContext } from 'react';
 import { Button, ButtonGroup, makeStyles } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';

--- a/src/components/DataViewSwitch.tsx
+++ b/src/components/DataViewSwitch.tsx
@@ -1,0 +1,43 @@
+import React, { useContext } from 'react';
+import { Button, ButtonGroup, makeStyles } from '@material-ui/core';
+import { useTranslation } from 'react-i18next';
+import { ApplicationContext } from '../contexts/ApplicationContext';
+
+export const DataViewSwitch: React.FC = () => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+  const { dataView, setDataView } = useContext(ApplicationContext);
+
+  return (
+    <>
+      <ButtonGroup size="small">
+        <Button
+          onClick={() => setDataView('list')}
+          className={
+            dataView === 'list' ? classes.buttonSelected : classes.button
+          }
+        >
+          {t('list')}
+        </Button>
+        <Button
+          onClick={() => setDataView('timeline')}
+          className={
+            dataView === 'timeline' ? classes.buttonSelected : classes.button
+          }
+        >
+          {t('timeline')}
+        </Button>
+      </ButtonGroup>
+    </>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  buttonSelected: {
+    backgroundColor: theme.palette.action.selected,
+    borderBottom: '2px solid white',
+  },
+  button: {
+    color: theme.palette.text.disabled,
+  },
+}));

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -116,11 +116,11 @@ export const Navigation: React.FC<Props> = ({
       </Box>
       <List>
         {navItem('dashboard', true)}
-        {navItem('network')}
+        {/* {navItem('network')} */}
         {navItem('messages')}
         {navItem('data')}
         {navItem('transactions')}
-        {navItem('settings')}
+        {/* {navItem('settings')} */}
       </List>
     </>
   );

--- a/src/contexts/ApplicationContext.tsx
+++ b/src/contexts/ApplicationContext.tsx
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import React, { Dispatch, SetStateAction } from 'react';
 import { DataView } from '../interfaces';
 

--- a/src/contexts/ApplicationContext.tsx
+++ b/src/contexts/ApplicationContext.tsx
@@ -1,0 +1,14 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import { DataView } from '../interfaces';
+
+export interface IApplicationContext {
+  dataView: DataView;
+  setDataView: Dispatch<SetStateAction<DataView>>;
+}
+
+export const ApplicationContext = React.createContext<IApplicationContext>({
+  dataView: 'list',
+  setDataView: () => {
+    /* default value */
+  },
+});

--- a/src/expanded-theme.ts
+++ b/src/expanded-theme.ts
@@ -19,8 +19,10 @@ import '@material-ui/core/styles';
 declare module '@material-ui/core/styles/createPalette' {
   interface Palette {
     tableRowAlternate: Palette['primary'];
+    timelineBackground: Palette['primary'];
   }
   interface PaletteOptions {
     tableRowAlternate: PaletteOptions['primary'];
+    timelineBackground: PaletteOptions['primary'];
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,6 +18,8 @@ export interface IDataTableColumn {
   value: string | number | JSX.Element | undefined;
 }
 
+export type DataView = 'timeline' | 'list';
+
 export enum TXStatus {
   Confirmed = 'confirmed',
   Pending = 'pending',
@@ -29,6 +31,14 @@ export interface IPieChartElement {
   label: string;
   value: number;
   color: string;
+}
+
+export interface ITimelineItem {
+  title?: string;
+  description?: string;
+  icon?: JSX.Element;
+  time?: string;
+  onClick?: () => void;
 }
 
 export interface IDataTableRecord {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -26,5 +26,7 @@
   "dateMined": "Date Mined",
   "transactionDetails": "Transaction Details",
   "viewTx": "View TX",
-  "last24Hours": "Last 24 Hours"
+  "last24Hours": "Last 24 Hours",
+  "list": "List",
+  "timeline": "Timeline"
 }

--- a/src/views/Data.tsx
+++ b/src/views/Data.tsx
@@ -21,8 +21,6 @@ import {
   CircularProgress,
   Box,
   makeStyles,
-  Button,
-  ButtonGroup,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
@@ -33,6 +31,7 @@ import { NamespaceContext } from '../contexts/NamespaceContext';
 import { DataTimeline } from '../components/DataTimeline/DataTimeline';
 import BroadcastIcon from 'mdi-react/BroadcastIcon';
 import { ApplicationContext } from '../contexts/ApplicationContext';
+import { DataViewSwitch } from '../components/DataViewSwitch';
 
 const PAGE_LIMITS = [10, 25];
 
@@ -44,7 +43,7 @@ export const Data: React.FC = () => {
   const { selectedNamespace } = useContext(NamespaceContext);
   const [currentPage, setCurrentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_LIMITS[0]);
-  const { dataView, setDataView } = useContext(ApplicationContext);
+  const { dataView } = useContext(ApplicationContext);
 
   const columnHeaders = [
     t('id'),
@@ -139,26 +138,7 @@ export const Data: React.FC = () => {
           </Grid>
           <Box className={classes.separator} />
           <Grid item>
-            <ButtonGroup>
-              <Button
-                onClick={() => setDataView('list')}
-                className={
-                  dataView === 'list' ? classes.buttonSelected : classes.button
-                }
-              >
-                {t('list')}
-              </Button>
-              <Button
-                onClick={() => setDataView('timeline')}
-                className={
-                  dataView === 'timeline'
-                    ? classes.buttonSelected
-                    : classes.button
-                }
-              >
-                {t('timeline')}
-              </Button>
-            </ButtonGroup>
+            <DataViewSwitch />
           </Grid>
         </Grid>
         {dataView === 'timeline' && (
@@ -210,12 +190,5 @@ const useStyles = makeStyles((theme) => ({
   },
   separator: {
     flexGrow: 1,
-  },
-  buttonSelected: {
-    backgroundColor: theme.palette.action.selected,
-    borderBottom: '2px solid white',
-  },
-  button: {
-    color: theme.palette.text.disabled,
   },
 }));

--- a/src/views/Messages/MessageDetails.tsx
+++ b/src/views/Messages/MessageDetails.tsx
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import React, { useState, useEffect, useContext } from 'react';
-import { DisplaySlide } from './Display/DisplaySlide';
+import { DisplaySlide } from '../../components/Display/DisplaySlide';
 import {
   Typography,
   Grid,
@@ -26,12 +26,12 @@ import {
   CircularProgress,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
-import { IMessage, IBatch } from '../interfaces';
-import { HashPopover } from './HashPopover';
+import { IMessage, IBatch } from '../../interfaces';
+import { HashPopover } from '../../components/HashPopover';
 import dayjs from 'dayjs';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import clsx from 'clsx';
-import { NamespaceContext } from '../contexts/NamespaceContext';
+import { NamespaceContext } from '../../contexts/NamespaceContext';
 import { useHistory } from 'react-router-dom';
 
 interface Props {

--- a/src/views/Messages/Messages.tsx
+++ b/src/views/Messages/Messages.tsx
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import React, { useState, useEffect, useContext } from 'react';
 import {
   Grid,

--- a/src/views/Messages/Messages.tsx
+++ b/src/views/Messages/Messages.tsx
@@ -205,12 +205,12 @@ export const Messages: React.FC = () => {
           </Grid>
         </Grid>
         {dataView === 'timeline' && (
-          <Grid className={classes.timelineContainer} container item>
+          <Grid className={classes.timelineContainer} xs={12} container item>
             <DataTimeline items={buildTimelineElements(messages)} />
           </Grid>
         )}
         {dataView === 'list' && (
-          <Grid className={classes.timelineContainer} xs={12} container item>
+          <Grid container item>
             <DataTable
               minHeight="300px"
               maxHeight="calc(100vh - 340px)"

--- a/src/views/Messages/Messages.tsx
+++ b/src/views/Messages/Messages.tsx
@@ -205,7 +205,7 @@ export const Messages: React.FC = () => {
           </Grid>
         </Grid>
         {dataView === 'timeline' && (
-          <Grid className={classes.timelineContainer} xs={12} container item>
+          <Grid className={classes.timelineContainer} container item>
             <DataTimeline items={buildTimelineElements(messages)} />
           </Grid>
         )}

--- a/src/views/Messages/Messages.tsx
+++ b/src/views/Messages/Messages.tsx
@@ -23,8 +23,6 @@ import {
   Box,
   CircularProgress,
   makeStyles,
-  ButtonGroup,
-  Button,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
@@ -42,6 +40,7 @@ import CheckIcon from 'mdi-react/CheckIcon';
 import BroadcastIcon from 'mdi-react/BroadcastIcon';
 import { NamespaceContext } from '../../contexts/NamespaceContext';
 import { ApplicationContext } from '../../contexts/ApplicationContext';
+import { DataViewSwitch } from '../../components/DataViewSwitch';
 import { useHistory } from 'react-router-dom';
 
 const PAGE_LIMITS = [10, 25];
@@ -56,7 +55,7 @@ export const Messages: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_LIMITS[0]);
   const { selectedNamespace } = useContext(NamespaceContext);
-  const { dataView, setDataView } = useContext(ApplicationContext);
+  const { dataView } = useContext(ApplicationContext);
 
   useEffect(() => {
     setLoading(true);
@@ -182,26 +181,7 @@ export const Messages: React.FC = () => {
           </Grid>
           <Box className={classes.separator} />
           <Grid item>
-            <ButtonGroup>
-              <Button
-                onClick={() => setDataView('list')}
-                className={
-                  dataView === 'list' ? classes.buttonSelected : classes.button
-                }
-              >
-                {t('list')}
-              </Button>
-              <Button
-                onClick={() => setDataView('timeline')}
-                className={
-                  dataView === 'timeline'
-                    ? classes.buttonSelected
-                    : classes.button
-                }
-              >
-                {t('timeline')}
-              </Button>
-            </ButtonGroup>
+            <DataViewSwitch />
           </Grid>
         </Grid>
         {dataView === 'timeline' && (
@@ -263,12 +243,5 @@ const useStyles = makeStyles((theme) => ({
   },
   separator: {
     flexGrow: 1,
-  },
-  buttonSelected: {
-    backgroundColor: theme.palette.action.selected,
-    borderBottom: '2px solid white',
-  },
-  button: {
-    color: theme.palette.text.disabled,
   },
 }));

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -22,8 +22,6 @@ import {
   Box,
   CircularProgress,
   makeStyles,
-  Button,
-  ButtonGroup,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
@@ -39,6 +37,7 @@ import { HashPopover } from '../../components/HashPopover';
 import { NamespaceContext } from '../../contexts/NamespaceContext';
 import { ApplicationContext } from '../../contexts/ApplicationContext';
 import { DataTimeline } from '../../components/DataTimeline/DataTimeline';
+import { DataViewSwitch } from '../../components/DataViewSwitch';
 
 const PAGE_LIMITS = [10, 25];
 
@@ -51,7 +50,7 @@ export const Transactions: React.FC = () => {
   const { selectedNamespace } = useContext(NamespaceContext);
   const [currentPage, setCurrentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_LIMITS[0]);
-  const { dataView, setDataView } = useContext(ApplicationContext);
+  const { dataView } = useContext(ApplicationContext);
 
   const columnHeaders = [
     t('hash'),
@@ -162,26 +161,7 @@ export const Transactions: React.FC = () => {
           </Grid>
           <Box className={classes.separator} />
           <Grid item>
-            <ButtonGroup>
-              <Button
-                onClick={() => setDataView('list')}
-                className={
-                  dataView === 'list' ? classes.buttonSelected : classes.button
-                }
-              >
-                {t('list')}
-              </Button>
-              <Button
-                onClick={() => setDataView('timeline')}
-                className={
-                  dataView === 'timeline'
-                    ? classes.buttonSelected
-                    : classes.button
-                }
-              >
-                {t('timeline')}
-              </Button>
-            </ButtonGroup>
+            <DataViewSwitch />
           </Grid>
         </Grid>
         {dataView === 'timeline' && (
@@ -233,12 +213,5 @@ const useStyles = makeStyles((theme) => ({
   },
   separator: {
     flexGrow: 1,
-  },
-  buttonSelected: {
-    backgroundColor: theme.palette.action.selected,
-    borderBottom: '2px solid white',
-  },
-  button: {
-    color: theme.palette.text.disabled,
   },
 }));

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -185,7 +185,7 @@ export const Transactions: React.FC = () => {
           </Grid>
         </Grid>
         {dataView === 'timeline' && (
-          <Grid className={classes.timelineContainer} container item>
+          <Grid className={classes.timelineContainer} xs={12} container item>
             <DataTimeline items={buildTimelineElements(transactions)} />
           </Grid>
         )}


### PR DESCRIPTION
Initial timeline for data/messages/tx. 

* Timeline panels can be displayed on both left and right.
* Still need to add infinite scrolling
* Added `ApplicationContext` to keep track of `dataView` state

<img width="1919" alt="Screen Shot 2021-06-01 at 10 43 15 PM" src="https://user-images.githubusercontent.com/10987380/120416364-0764f900-c32b-11eb-8700-2d8174f31145.png">

