### PR TITLE
persist filter options across views

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ firefly-ui is the UI explorer for [FireFly](https://github.com/kaleido-io/firefl
 
 ### Get started locally
 
-* Clone / build firefly-ui
+- Clone / build firefly-ui
+
 ```bash
 git clone https://github.com/kaleido-io/firefly-ui
 npm i

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import { Data } from './views/Data';
 import { AppWrapper } from './components/AppWrapper';
 import { NamespaceContext } from './contexts/NamespaceContext';
 import { ApplicationContext } from './contexts/ApplicationContext';
-import { INamespace, DataView } from './interfaces';
+import { INamespace, DataView, CreatedFilterOptions } from './interfaces';
 
 const history = createBrowserHistory({
   basename: process.env.PUBLIC_URL,
@@ -93,6 +93,9 @@ function App() {
   const [namespaces, setNamespaces] = useState<INamespace[]>([]);
   const [selectedNamespace, setSelectedNamespace] = useState<string>('');
   const [dataView, setDataView] = useState<DataView>('list');
+  const [createdFilter, setCreatedFilter] = useState<CreatedFilterOptions>(
+    '24hours'
+  );
 
   useEffect(() => {
     fetch('/api/v1/namespaces')
@@ -131,7 +134,9 @@ function App() {
           setSelectedNamespace,
         }}
       >
-        <ApplicationContext.Provider value={{ dataView, setDataView }}>
+        <ApplicationContext.Provider
+          value={{ dataView, setDataView, createdFilter, setCreatedFilter }}
+        >
           <Router history={history}>
             <AppWrapper>
               <Switch>

--- a/src/contexts/ApplicationContext.tsx
+++ b/src/contexts/ApplicationContext.tsx
@@ -15,16 +15,22 @@
 // limitations under the License.
 
 import React, { Dispatch, SetStateAction } from 'react';
-import { DataView } from '../interfaces';
+import { DataView, CreatedFilterOptions } from '../interfaces';
 
 export interface IApplicationContext {
   dataView: DataView;
   setDataView: Dispatch<SetStateAction<DataView>>;
+  createdFilter: CreatedFilterOptions;
+  setCreatedFilter: Dispatch<SetStateAction<CreatedFilterOptions>>;
 }
 
 export const ApplicationContext = React.createContext<IApplicationContext>({
   dataView: 'list',
   setDataView: () => {
+    /* default value */
+  },
+  createdFilter: '24hours',
+  setCreatedFilter: () => {
     /* default value */
   },
 });

--- a/src/views/Data.tsx
+++ b/src/views/Data.tsx
@@ -13,6 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 import React, { useState, useEffect, useContext } from 'react';
 import {
   Grid,
@@ -24,12 +25,7 @@ import {
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
-import {
-  IDataTableRecord,
-  IData,
-  ITimelineItem,
-  CreatedFilterOptions,
-} from '../interfaces';
+import { IDataTableRecord, IData, ITimelineItem } from '../interfaces';
 import { DataTable } from '../components/DataTable/DataTable';
 import { HashPopover } from '../components/HashPopover';
 import { NamespaceContext } from '../contexts/NamespaceContext';
@@ -49,9 +45,8 @@ export const Data: React.FC = () => {
   const { selectedNamespace } = useContext(NamespaceContext);
   const [currentPage, setCurrentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_LIMITS[0]);
-  const { dataView } = useContext(ApplicationContext);
-  const [createdFilter, setCreatedFilter] = useState<CreatedFilterOptions>(
-    '24hours'
+  const { dataView, createdFilter, setCreatedFilter } = useContext(
+    ApplicationContext
   );
 
   const createdQueryOptions = [

--- a/src/views/Messages/Messages.tsx
+++ b/src/views/Messages/Messages.tsx
@@ -30,7 +30,6 @@ import {
   ITimelineItem,
   IMessage,
   IHistory,
-  CreatedFilterOptions,
 } from '../../interfaces';
 import { DataTable } from '../../components/DataTable/DataTable';
 import { DataTimeline } from '../../components/DataTimeline/DataTimeline';
@@ -56,9 +55,8 @@ export const Messages: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_LIMITS[0]);
   const { selectedNamespace } = useContext(NamespaceContext);
-  const { dataView } = useContext(ApplicationContext);
-  const [createdFilter, setCreatedFilter] = useState<CreatedFilterOptions>(
-    '24hours'
+  const { dataView, createdFilter, setCreatedFilter } = useContext(
+    ApplicationContext
   );
 
   const createdQueryOptions = [

--- a/src/views/Transactions/Transactions.tsx
+++ b/src/views/Transactions/Transactions.tsx
@@ -31,7 +31,6 @@ import {
   IDataTableRecord,
   ITransaction,
   ITimelineItem,
-  CreatedFilterOptions,
 } from '../../interfaces';
 import { DataTable } from '../../components/DataTable/DataTable';
 import { HashPopover } from '../../components/HashPopover';
@@ -52,9 +51,8 @@ export const Transactions: React.FC = () => {
   const { selectedNamespace } = useContext(NamespaceContext);
   const [currentPage, setCurrentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_LIMITS[0]);
-  const { dataView } = useContext(ApplicationContext);
-  const [createdFilter, setCreatedFilter] = useState<CreatedFilterOptions>(
-    '24hours'
+  const { dataView, createdFilter, setCreatedFilter } = useContext(
+    ApplicationContext
   );
 
   const createdQueryOptions = [


### PR DESCRIPTION
Now the created filter will persist when switching between views, so context is not lost when moving across the explorer.

 - readme style updates